### PR TITLE
Allow an override of the Localstack service name

### DIFF
--- a/localstack/Chart.yaml
+++ b/localstack/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for localstack
 name: localstack
-version: 0.2.0
+version: 0.3.0

--- a/localstack/templates/service.yaml
+++ b/localstack/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
   name: {{ template "fullname" . }}
+{{- end }}
   labels:
     app: {{ template "name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}


### PR DESCRIPTION
I am using localstack in Jenkins X. When a preview environment is created, and localstack is deployed as a side-car, a deterministic name for the localstack service is preferred so that it can be accessed via http://service-name (for example, http://localstack). By defaulting to the fullname, which is a combination of namespace and service name, the localstack service host URL differs for each preview environment; and so configuring the application-under-test to access localstack becomes difficult.