### PR TITLE
fix external hostname env var

### DIFF
--- a/localstack/templates/deployment.yaml
+++ b/localstack/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - name: DEFAULT_REGION
               value: {{ .defaultRegion | quote}}
               {{- end }}
-            - name: HOST_EXTERNAL
+            - name: HOSTNAME_EXTERNAL
               {{- if .hostExternal }}
               value: {{.hostExternal | quote}}
               {{- else }}


### PR DESCRIPTION
the external hostname var does not match up with the docs https://github.com/localstack/localstack#configurations