### PR TITLE
Upgrade localstack kubernetes resource definitions

### DIFF
--- a/localstack/Chart.yaml
+++ b/localstack/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for localstack
 name: localstack
-version: 0.4.0
+version: 1.0.0

--- a/localstack/templates/deployment.yaml
+++ b/localstack/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/localstack/templates/ingress.yaml
+++ b/localstack/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}


### PR DESCRIPTION
Kubernetes Version: v1.18.8

The current localstack helm definition is not compatible with the latest kubernetes version: 

```
Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Deployment" in version "extensions/v1beta1"
```

This will be resolved with this merge request by upgrading the resource API names. 